### PR TITLE
offchain-relayer: add static provider; fix event listener

### DIFF
--- a/offchain-relayer/package.json
+++ b/offchain-relayer/package.json
@@ -15,8 +15,8 @@
   },
   "scripts": {
     "build-types": "typechain --target=ethers-v5 --out-dir=src/ethers-contracts ../contracts/build/contracts/*.json",
-    "build": "npm run build-types",
+    "build": "yarn build-types",
     "clean": "rm -rf node_modules src/ethers-contracts",
-    "start": "npm run build && ts-node src/main.ts"
+    "start": "yarn build && ts-node src/main.ts"
   }
 }


### PR DESCRIPTION
1. Added static provider (so static calls don't use websocket provider for source chain).
2. Removed pending transaction listening and added specific Wormhole event listening.